### PR TITLE
Update Ruby for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.6
+  - 2.4.7
 sudo: false
 before_script:
   - gem install csvlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 2.4.7
 sudo: false
 before_script:
+  - gem install activesupport -v 5.2.3
   - gem install csvlint
 script: csvlint loeb-copyright.csv --schema=schema.json


### PR DESCRIPTION
Use Ruby 2.4.7 since csvlint isn't tested on 2.5 and 2.6.