### PR TITLE
Fixed Broken Link for Stanford Collections in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that some Loebs were published with different works/editions/translations u
 
 Helpful links:
 
-* [Stanford Copyright Renewal Database](https://collections.stanford.edu/copyrightrenewals/bin/page?forward=home)
+* [Stanford Copyright Renewal Database](https://exhibits.stanford.edu/copyrightrenewals)
 * [Online Books Page Copyright Registration and Renewal Records](http://onlinebooks.library.upenn.edu/cce/)
 * [US Copyright Office Public Catalog (1978-present)](http://cocatalog.loc.gov/cgi-bin/Pwebrecon.cgi?DB=local&PAGE=First)
 * The source of [Bill Thayer's "A Selection of Articles from Various Journals in the Fields of Classics and Archaeology"](http://penelope.uchicago.edu/Thayer/E/Journals/Roman/home.html) has a `DEATHDATES` field for checking 70-years-since-author-death


### PR DESCRIPTION
The current link for Stanford's Copyright Renewal Database in the readme is broken and is updated in this pr.

Broken link: https://collections.stanford.edu/copyrightrenewals/bin/page?forward=home 
Corrected link: https://exhibits.stanford.edu/copyrightrenewals